### PR TITLE
Update start name retrieval and Ivy engine version

### DIFF
--- a/process-analyser-core/src/com/axonivy/solutions/process/analyser/core/internal/ProcessStartFactory.java
+++ b/process-analyser-core/src/com/axonivy/solutions/process/analyser/core/internal/ProcessStartFactory.java
@@ -2,6 +2,8 @@ package com.axonivy.solutions.process.analyser.core.internal;
 
 import static com.axonivy.solutions.process.analyser.core.constants.ProcessAnalyticsConstants.SLASH;
 
+import java.util.Locale;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.solutions.process.analyser.core.enums.StartElementType;
@@ -49,7 +51,7 @@ public class ProcessStartFactory {
 
   private static String getStartName(AbstractStartElement startElement) {
     if (startElement != null) {
-      var localeName = startElement.names().current();
+      var localeName = startElement.getName();
       if (StringUtils.isNoneBlank(localeName)) {
         return localeName;
       }

--- a/process-analyser-test/pom.xml
+++ b/process-analyser-test/pom.xml
@@ -6,7 +6,7 @@
   <version>12.0.6-SNAPSHOT</version>
   <packaging>iar-integration-test</packaging>
   <properties>
-    <ivy.engine.version>12.0.0</ivy.engine.version>
+    <ivy.engine.version>12.0.9</ivy.engine.version>
     <project.build.plugin.version>12.0.0</project.build.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tester.version>12.0.1</tester.version>


### PR DESCRIPTION
Refactored ProcessStartFactory to use getName() instead of names().current() for start element names. Updated ivy.engine.version in process-analyser-test/pom.xml from 12.0.0 to 12.0.9.